### PR TITLE
Removed max line length check from pep8 for travis

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,2 @@
+[pep8]
+ignore = E501

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
     - pip install -r requirements.txt
     - pip install pep8 --use-mirrors
 before_script:
-    - "pep8 --exclude=migrations apps"
+    - "pep8 --exclude=migrations --config=.pep8 apps"
 script:
     - echo "Should do more stuff here"


### PR DESCRIPTION
This should remove the max line length from pep8; also, if you want your local pep8 checks to abide by project standards, you should do something like this:

```
pep8 --config="/PATH/TO/PROJECT/.pep8"
```

If you're using Sublime Text and the PEP8 Linter package, you should take a look at [these instructions](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html) to see how to pass command line arguments to the linter.
