### PR TITLE
Moved messages into base.html so everyone can use them

### DIFF
--- a/apps/admin/settings.py
+++ b/apps/admin/settings.py
@@ -151,8 +151,11 @@ LOGGING = {
 }
 
 from django.contrib.messages import constants as message_constants
-MESSAGE_TAGS = {message_constants.DEBUG: 'debug',
-                message_constants.INFO: 'info',
-                message_constants.SUCCESS: 'success',
-                message_constants.WARNING: 'warning',
-                message_constants.ERROR: 'danger',}
+
+MESSAGE_TAGS = {
+    message_constants.DEBUG: 'alert-debug',
+    message_constants.INFO: 'alert-info',
+    message_constants.SUCCESS: 'alert-success',
+    message_constants.WARNING: 'alert-warning',
+    message_constants.ERROR: 'alert-danger',
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,9 @@
       .navbar-nav > li.navbar-left {
         float: left !important;
       }
+      .theme-showcase {
+        margin-top:1em;
+      }
     </style>
 
     <!-- <link=href="https://raw.github.com/ehynds/jquery-ui-multiselect-widget/1.13/jquery.multiselect.css" rel="stylesheet">-->
@@ -90,7 +93,13 @@
     {% block dropmenu %}
 
     {% endblock %}
+    
     <div class="container theme-showcase" role="main">
+      {% if messages %}
+          {% for message in messages %}
+          <div class="alert {% if message.tags %} {{ message.tags }} {% else %} alert-info {% endif %}" role="alert">{{ message }}</div>
+          {% endfor %}
+      {% endif %}
       {% block content %}   
 
       {% endblock %}

--- a/templates/web_fe/login.html
+++ b/templates/web_fe/login.html
@@ -6,13 +6,6 @@
 
 
 <form id="login_form" action="login" method="post" class="form-signin">
-  {% if messages %}
-    {% for message in messages %}
-       <div class="alert alert-{{message.tags}}" role="alert">
-        {{ message }}
-      </div>
-    {% endfor %}
-  {% endif %}
 
   <h2 class="form-signin-heading">Please Sign In</h2>
   {% csrf_token %}


### PR DESCRIPTION
Fix for #55; moves message rendering into base.html, and adds a smidgen of margin to the main container because I was getting tired of everything being smack up against the toolbar.
