### PR TITLE
Adds support for flake8 sublime plugin to ignore line length

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,2 +1,4 @@
+[flake8]
+ignore = E501
 [pep8]
 ignore = E501


### PR DESCRIPTION
If you're using sublime text and want to have PEP8 linting, but don't want error messages about line length, this will fix it (though you'll want to remove Pep8Lint and install Flake8).
