### PR TITLE
Fixed broken link to bootstrap js

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,7 +50,7 @@
     <!-- <link=href="https://raw.github.com/ehynds/jquery-ui-multiselect-widget/1.13/jquery.multiselect.css" rel="stylesheet">-->
     <!-- <link=href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/ui-lightness/jquery-ui.min.css" rel="stylesheet">-->
     <!--<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>-->
-    <script src="static/js/bootstrap.min.js"></script>
+    <script src="/static/js/bootstrap.min.js"></script>
   </head>
   <body role="document" class="day">
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">


### PR DESCRIPTION
All links to static have to be absolute, not relative.

@mattben @sterlingbaldwin Mind merging?
