### PR TITLE
Fixed content type issue

### DIFF
--- a/apps/issues/views.py
+++ b/apps/issues/views.py
@@ -79,7 +79,8 @@ def expects_json(f):
     Decorator that parses HTTP body and passes it in as a kwarg (json_data=)
     """
     def wrapper(request, *args, **kwargs):
-        if request.META.get("CONTENT_TYPE", None) == "application/json":
+        # Firefox appends "; charset utf8" to content type header, so we'll just do this in a slightly smarter way...
+        if "application/json" in request.META.get("CONTENT_TYPE", ''):
             data = request.body
             try:
                 data = json.loads(data)


### PR DESCRIPTION
There was an issue with Firefox that had "charset utf-8" appended to the content type header, which I was using to check if there was any JSON data in the request. This has now been fixed.
