### PR TITLE
Fixes the issue with page loading when ESGF is down

### DIFF
--- a/apps/web_fe/views.py
+++ b/apps/web_fe/views.py
@@ -254,13 +254,23 @@ def grid(request):
 
     try:
         r = requests.get(
-            'http://pcmdi9.llnl.gov/esgf-node-manager/registration.xml')
+            'http://pcmdi9.llnl.gov/esgf-node-manager/registration.xml', timeout=0.1)
         f = StringIO(r.content)
         out = open('scripts/registration.xml', 'w')
         out.write(f.read())
         out.close()
     except Exception as e:
-        print repr(e)
+        import traceback
+        if 'requests.exceptions.ConnectTimeout' in str(sys.exc_info()):
+            node_list = []
+            return HttpResponse(render_template(request, "web_fe/grid.html", {'nodes': node_list}))
+        print '1', e.__doc__
+        print '2', sys.exc_info()
+        print '3', sys.exc_info()[0]
+        print '4', sys.exc_info()[1]
+        print '5', traceback.tb_lineno(sys.exc_info()[2])
+        ex_type, ex, tb = sys.exc_info()
+        print '6', traceback.print_tb(tb)
         return HttpResponse(status=404)
     tree = parse('scripts/registration.xml')
 

--- a/templates/web_fe/add_credentials.html
+++ b/templates/web_fe/add_credentials.html
@@ -6,8 +6,9 @@
 		.fa-check {
 			color: green; 
 			float: left; 
-			height: 22px; 
+			height: 25px; 
 			width: 50px;
+			margin-right: 10px;
 		}
 	</style>
 	  <!-- Font Awesome -->
@@ -21,29 +22,37 @@
 			{% if "esgf" in stored_credentials %}
 				<i class="fa fa-check">Saved</i>
 			{% endif %}
+			<label for="esgf-username">ESGF Username</label>
 			<input type="text" name="esgf-username" value="" id="esgf-username" class="form-control" placeholder="ESGF OpenId">
-			<input type="text" name="esgf-password" value="" id="esgf-password" class="form-control" placeholder="ESGF Password">
+			<label for="esgf-password">ESGF Username</label>
+			<input type="password" name="esgf-password" value="" id="esgf-password" class="form-control" placeholder="ESGF Password">
 			<br>
 			<h2 class="form-signin-heading">Velo</h2>
 			{% if "velo" in stored_credentials %}
 				<i class="fa fa-check">Saved</i>
 			{% endif %}
+			<label for="velo-username">Velo Username</label>
 			<input type="text" name="velo-username" value="" id="velo-username" class="form-control" placeholder="Velo Username">
-			<input type="text" name="velo-password" value="" id="velo-password" class="form-control" placeholder="Velo Password">
+			<label for="velo-password">Velo Username</label>
+			<input type="password" name="velo-password" value="" id="velo-password" class="form-control" placeholder="Velo Password">
 			<br>
 			<h2 class="form-signin-heading">Github</h2>
 			{% if "github" in stored_credentials %}
 				<i class="fa fa-check">Saved</i>
 			{% endif %}
+			<label for="github-username">Github Username</label>
 			<input type="text" name="github-username" value="" id="github-username" class="form-control" placeholder="Github Username">
-			<input type="text" name="github-password" value="" id="github-password" class="form-control" placeholder="Github Password">
+			<label for="github-password">Github Username</label>
+			<input type="password" name="github-password" value="" id="github-password" class="form-control" placeholder="Github Password">
 			<br>
 			<h2 class="form-signin-heading">Jira</h2>
 			{% if "jira" in stored_credentials %}
 				<i class="fa fa-check">Saved</i>
 			{% endif %}
+			<label for="jira-username">Jira Username</label>
 			<input type="text" name="jira-username" value="" id="jira-username" class="form-control" placeholder="Jira Username">
-			<input type="text" name="jira-password" value="" id="jira-password" class="form-control" placeholder="Jira Password">
+			<label for="jira-username">Jira Username</label>
+			<input type="password" name="jira-password" value="" id="jira-password" class="form-control" placeholder="Jira Password">
 			<br>
 			<a href="javascript:void(0)" class="btn btn-lg btn-primary btn-block" onclick="check_credentials()">Check Credentials</a>
 			<a href="javascript:void(0)" class="btn btn-lg btn-primary btn-block" onclick="submit_credentials()">Add Credentials</a>

--- a/tests/robot/web_fe/dashboard/common_resources.txt
+++ b/tests/robot/web_fe/dashboard/common_resources.txt
@@ -7,29 +7,29 @@ Library        Selenium2Library  timeout=10  implicit_wait=0.5
 
 *** Variables ***
 
-${SERVER}			localhost:8000
-${DASHBOARD}		http://${SERVER}/acme/grid/
-${LOGIN URL}		http://${SERVER}/acme/login?next=/acme/
-${BROWSER}			safari
-${VALID_USER}		testuser
-${VALID_PASS}		testpass
+${SERVER}           localhost:8000
+${DASHBOARD}        http://${SERVER}/acme/grid/
+${LOGIN URL}        http://${SERVER}/acme/login?next=/acme/
+${BROWSER}          ff
+${VALID_USER}       testuser
+${VALID_PASS}       testpass
 ${DELAY}            1000
-${DASHBOARD}		http://${SERVER}/acme/grid/
+${DASHBOARD}        http://${SERVER}/acme/grid/
 
 
 *** Keywords ***
 
 Open Browser And Log In
-	[Documentation]  Logs in and goes to the dashboard
-	Open Browser  ${LOGIN URL}  ${BROWSER}
-	Set Browser Implicit Wait  0.5
-	Maximize Browser Window
-	Title Should Be	 login
-	Input Text  username  testuser
-	Input Text  password  testpass
-	Click Button  Sign In
-	Page Should Contain  successfully loged in
-	Click Element  xpath=/html/body/div[1]/div/div[2]/ul/li[3]/a
+    [Documentation]  Logs in and goes to the dashboard
+    Open Browser  ${LOGIN URL}  ${BROWSER}
+    Set Browser Implicit Wait  0.5
+    Maximize Browser Window
+    Title Should Be  login
+    Input Text  username  testuser
+    Input Text  password  testpass
+    Click Button  Sign In
+    Page Should Contain  successfully loged in
+    Click Element  xpath=/html/body/div[1]/div/div[2]/ul/li[3]/a
 
 
 Close Tile  [Arguments]  ${tilename}


### PR DESCRIPTION
Since the ESGF nodes are going to be down for a while, I added a timeout for the node info request, where if it times out the dashboard will load, just with no nodes. Also adds labels for users adding new credentials, so they can see which ones they already have.
