### PR TITLE
Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ sudo:
 before_script:
     - "pep8 --exclude=migrations --config=.pep8 apps"
 script:
-    - "./manage.py test apps.web_fe.tests -v 2"
+    - "./manage.py test -v 2 --liveserver=localhost:8000"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ sudo:
 before_script:
     - "pep8 --exclude=migrations --config=.pep8 apps"
 script:
-    - "./manage.py test -v 2 --liveserver=localhost:8000"
+    - "./manage.py test apps/* -v 2 --liveserver=localhost:8000"
 

--- a/apps/admin/settings.py
+++ b/apps/admin/settings.py
@@ -52,7 +52,7 @@ MANAGERS = ADMINS
 ##########################################################
 
 TEMPLATE_DIRS = (
-    os.path.join(os.path.abspath("."), 'templates')
+    os.path.join(os.path.abspath("."), 'templates'),
 )
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
@@ -91,18 +91,12 @@ MEDIA_ROOT = ''
 # Examples: "http://example.com/media/", "http://media.example.com/"
 MEDIA_URL = ''
 
-# Absolute path to the directory static files should be collected to.
-# Don't put anything in this directory yourself; store your static files
-# in apps' "static/" subdirectories and in STATICFILES_DIRS.
-# Example: "/var/www/example.com/static/"
-STATIC_ROOT = ''
-
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
 STATIC_URL = '/static/'
 
 # define in local_settings.py
-# STATICFILES_DIRS = ()
+STATICFILES_DIRS = ("static",)
 
 
 # List of finder classes that know how to find static files in

--- a/apps/admin/settings.py
+++ b/apps/admin/settings.py
@@ -147,7 +147,7 @@ INSTALLED_APPS = (
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = [
     '--with-coverage',
-    '--cover-package=apps.web_fe',
+    '--cover-package=web_fe',
     '--cover-html'
 ]
 

--- a/apps/admin/settings.py
+++ b/apps/admin/settings.py
@@ -137,7 +137,6 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'web_fe',
     'django.contrib.admin',
-    'south',
     'captcha',
     'issues',
     'django_nose'

--- a/apps/issues/templatetags/issues_extras.py
+++ b/apps/issues/templatetags/issues_extras.py
@@ -1,7 +1,7 @@
 from django import template
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
-from apps.issues.models import IssueCategory
+from issues.models import IssueCategory
 
 register = template.Library()
 

--- a/apps/issues/views.py
+++ b/apps/issues/views.py
@@ -8,7 +8,7 @@ from django.http import (
 )
 from django.template import RequestContext, loader
 from django.core.urlresolvers import reverse
-from templatetags.issues import render_question_tree
+from templatetags.issues_extras import render_question_tree
 from django.contrib import messages
 from models import (
     IssueSource,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.6
+Django==1.8
 Jinja2==2.7.3
 MarkupSafe==0.23
 South==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Django==1.8
 Jinja2==2.7.3
 MarkupSafe==0.23
-South==1.0.1
 django-recaptcha==1.0.3
 esgf-pyclient==0.1.2
 github3.py==0.9.4

--- a/templates/issues/questions.html
+++ b/templates/issues/questions.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-{% load issues %}
+{% load issues_extras %}
 <style>
 	.qb_body li {
 		list-style-type: none;


### PR DESCRIPTION
I upgraded Django to 1.8, and tweaked the structure a very tiny amount to accommodate that.

MAJOR CHANGES:
1. To migrate your database off of south and to the new Django migration scheme, you must do this:
   `
   manage.py migrate --fake-initial
   `
2. The staticfiles config was a little weird. `STATICFILES_DIRS` is supposed to be system wide (points at all static files locations that you want to call out specifically for `staticfiles` to gather), and `STATICFILES_ROOT` is meant to be install-specific. I switched those around, so you're going to need to define `STATICFILES_ROOT` in your `local_settings.py`.
3. `apps` is no longer a package; however, the folder is on the path, so you should still be able to import from your module as appropriate. I think that I was the only person using `apps.APPNAME.module`, which I've fixed up.

Do remember to do a `pip install -r requirements.txt` after this PR is merged, so you'll be on the newer Django version.
