### PR TITLE
Cdat panel with launcher

### DIFF
--- a/apps/web_fe/urls.py
+++ b/apps/web_fe/urls.py
@@ -28,6 +28,7 @@ urlpatterns = patterns('',
                        url(r'^node_search/', views.node_search),
                        url(r'^load_facets/', views.load_facets),
                        url(r'^userdata/image/(?P<path>.*\.png)$', views.send_image),
+                       url(r'^vtk/', views.vtkweb_launcher),
                        # url(r'^esgf_download/', views.esgf_download),
                        )
 

--- a/apps/web_fe/views.py
+++ b/apps/web_fe/views.py
@@ -566,6 +566,29 @@ def credential_check_existance(request):
         return HttpResponse(status=404)
 
 
+@csrf_exempt  # should probably fix this at some point
+@login_required
+def vtkweb_launcher(request):
+    """Proxy requests to the configured launcher service."""
+    import requests
+    try:
+        from local_settings import VISUALIZATION_LAUNCHER
+    except ImportError:
+        VISUALIZATION_LAUNCHER = None
+
+    if not VISUALIZATION_LAUNCHER:
+        # unconfigured launcher
+        return HttpResponse(status=404)
+
+    # TODO: add status and delete methods
+    if request.method == 'POST':
+        req = requests.post(VISUALIZATION_LAUNCHER, request.body)
+        if req.ok:
+            return HttpResponse(req.content)
+        else:
+            return HttpResponse(status=500)
+
+
 def print_debug(e):
     import traceback
     print '1', e.__doc__

--- a/apps/web_fe/views.py
+++ b/apps/web_fe/views.py
@@ -218,6 +218,10 @@ def dashboard(request):
     import xml.etree.ElementTree as ET
     import requests
     from StringIO import StringIO
+    try:
+        from local_settings import VISUALIZATION_LAUNCHER
+    except ImportError:
+        VISUALIZATION_LAUNCHER = None
 
     nodes = ESGFNode.objects.all()
     if len(nodes) == 0:
@@ -230,7 +234,8 @@ def dashboard(request):
         for node in nodes:
             node.refresh()
 
-    return HttpResponse(render_template(request, "web_fe/dashboard.html", {}))
+    data = {'vis_launcher': VISUALIZATION_LAUNCHER}
+    return HttpResponse(render_template(request, "web_fe/dashboard.html", data))
 
 
 @login_required

--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -29,3 +29,7 @@ RECAPTCHA_PRIVATE_KEY = ''
 # CAN NOT BE EMPTY http://www.miniwebtool.com/django-secret-key-generator
 SECRET_KEY = ''
 JAR_PATH = '-Djava.class.path=%s/static/java/VeloAPI.jar' % _root
+
+# Add the visualization launcher address here
+# this is the default when `./start` is run locally
+VISUALIZATION_LAUNCHER = 'http://localhost:7000/vtk'

--- a/static/js/cdat.js
+++ b/static/js/cdat.js
@@ -39,10 +39,10 @@
          *       function (code, reason) { console.log('load failed because ' + reason); }
          *   );
          */
-        setup: function (launcher, config) {
+        setup: function (config) {
             config = config || {};
             config.application  = config.application || 'default';
-            config.sessionManagerURL = launcher;
+            config.sessionManagerURL = 'vtk/';
             open = new $.Deferred();
 
             /*
@@ -59,7 +59,11 @@
                 config,
                 function (_connection) {
                     connection = _connection;
-                    open.resolve(connection);
+                    if (connection.error) {
+                        open.reject(null, connection.error);
+                    } else {
+                        open.resolve(connection);
+                    }
                 },
                 function (code, reason) {
                     open.reject(code, reason);
@@ -151,7 +155,7 @@
 
             open.then(
                 function (connection) {
-                    connections.session.call(
+                    connection.session.call(
                         'cdat.view.create',
                         [
                             config.file,

--- a/static/js/cdat.js
+++ b/static/js/cdat.js
@@ -23,7 +23,7 @@
     * global module for CDAT specific methods
     * @namespace
     */
-    cdat = {
+    var cdat = {
         /**
          * This is an initialization function that should be called once to initiate
          * the vtkweb connection.

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(function() {
 
 
 	/****************************************
@@ -6,6 +6,13 @@ $(document).ready(function() {
 
 	 	These could probably all be put in a resource file somewhere
 	 ***************************************/
+
+	// call the vis server setup
+	if (cdat.visualization_launcher) {
+		cdat.setup(cdat.visualization_launcher);
+	} else {
+		console.log('No visualization server given in the config');
+	}
 
 	var docHeight, docWidth, maxCols, maxHeight, tileHeight, tileWidth;
 	calcMaxSize();
@@ -191,6 +198,20 @@ $(document).ready(function() {
 			var name = $(this).attr('id');
 			var content = '';
 			switch (name) {
+				case 'cdat':
+					content = '<div id="cdat-vis"></div>';
+
+					// for example
+					cdat.show({
+						file: 'http://test.opendap.org/dap/netcdf/examples/cami_0000-09-01_64x128_L26_c030918.nc',
+						variable: 'TS',
+						node: '#cdat-vis'
+					}).then(
+						function () {console.log('cdat vis success');}, // indicate success or error in the console
+						function () {console.log('\n'.join(arguments));}
+					);
+
+					break;
 				case 'esgf':
 					content = '<div id="esgf-node-tree"></div>';
 					initFileTree('esgf_window');

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -8,11 +8,10 @@ $(function() {
 	 ***************************************/
 
 	// call the vis server setup
-	if (cdat.visualization_launcher) {
-		cdat.setup(cdat.visualization_launcher);
-	} else {
-		console.log('No visualization server given in the config');
-	}
+	cdat.setup()
+		.then(function () { console.log('Vis instance launched'); },
+		      function () { console.log(arguments); });
+
 
 	var docHeight, docWidth, maxCols, maxHeight, tileHeight, tileWidth;
 	calcMaxSize();
@@ -208,7 +207,7 @@ $(function() {
 						node: '#cdat-vis'
 					}).then(
 						function () {console.log('cdat vis success');}, // indicate success or error in the console
-						function () {console.log('\n'.join(arguments));}
+						function () {console.log(arguments);}
 					);
 
 					break;

--- a/templates/web_fe/dashboard.html
+++ b/templates/web_fe/dashboard.html
@@ -35,11 +35,11 @@
   <script src='http://cdnjs.cloudflare.com/ajax/libs/velocity/0.2.1/jquery.velocity.min.js'></script> 
 
   <!-- vtkweb -->
-  <script type="text/javascript" src="{% static "vtkweb/js/autobahn.min.js" %}">
-  <script type="text/javascript" src="{% static "vtkweb/js/jquery.hammer.min.js" %}">
-  <script type="text/javascript" src="{% static "vtkweb/js/gl-matrix-min.js" %}">
-  <script type="text/javascript" src="{% static "vtkweb/js/vtkweb-all.js" %}">
-  <script type="text/javascript" src="{% static "js/cdat.js" %}">
+  <script type="text/javascript" src="{% static "vtkweb/js/autobahn.min.js" %}"></script>
+  <script type="text/javascript" src="{% static "vtkweb/js/jquery.hammer.min.js" %}"></script>
+  <script type="text/javascript" src="{% static "vtkweb/js/gl-matrix-min.js" %}"></script>
+  <script type="text/javascript" src="{% static "vtkweb/js/vtkweb-all.js" %}"></script>
+  <script type="text/javascript" src="{% static "js/cdat.js" %}"></script>
   <script type="text/javascript">cdat.visualization_launcher = "{{ vis_launcher }}";</script>
 {% endblock %}
 

--- a/templates/web_fe/dashboard.html
+++ b/templates/web_fe/dashboard.html
@@ -40,6 +40,7 @@
   <script type="text/javascript" src="{% static "vtkweb/js/gl-matrix-min.js" %}">
   <script type="text/javascript" src="{% static "vtkweb/js/vtkweb-all.js" %}">
   <script type="text/javascript" src="{% static "js/cdat.js" %}">
+  <script type="text/javascript">cdat.visualization_launcher = "{{ vis_launcher }}";</script>
 {% endblock %}
 
 


### PR DESCRIPTION
@sterlingbaldwin This might be working, but I'm having trouble with my UV-CDAT install at the moment :/.  Anyway, you just need to define `VISUALIZATION_LAUNCHER` in local settings.

The import part of the code is [here](https://github.com/ACME-OUI/acme-web-fe/compare/cdat-panel?expand=1#diff-525d91d59075e0825aaa4c2de27389ceR204) where the RPC is performed.

Note: this is a race condition because my function expects the `#cdat-vis` node to exist when it is executed.  Besides that, I just need to attach resize handlers for when the dashboard view changes.  It shouldn't take to much longer once I get UV-CDAT running again.
